### PR TITLE
Documentation/wiki/Contributors - converted HTML to MD

### DIFF
--- a/Source/Documentation/wiki/Contributors/ajstadlin.md
+++ b/Source/Documentation/wiki/Contributors/ajstadlin.md
@@ -1,37 +1,24 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" class="">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta content="ajstadlin" property="profile:username" />
-<!--HtmlToGmd.Head-->
-<title>Contributor - ajstadlin</title>
-<!--/HtmlToGmd.Head-->
-</head>
-<body>
-<!--HtmlToGmd.Body-->
-<h1>
-<a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md"><img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/openPDC_Logo.png" alt="The Open Source Phasor Data Concentrator" /></a></h1>
-<div id="NavigationMenu">
-<table style="width: 100%; border-collapse: collapse; border: 0px solid gray;">
-<tr>
-<td style="width: 25%; text-align:center;"><b><a href="http://www.gridprotectionalliance.org">Grid Protection Alliance</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC">openPDC Project on GitHub</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md">openPDC Wiki Home</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Documentation_Home.md">Documentation</a></b></td>
-</tr>
-</table>
-</div>
-<hr />
-<!--/HtmlToGmd.Body-->
-<img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/Contributors/ajstadlin.png" alt="ajstadlin" /><h2 class="user_name" style="display: inline">ajstadlin</h2>
-<h3>Personal Statement</h3>
-<div class="WikiContent" id="WikiContentDiv">
-I am a full time systems administrator, software engineer, and electronics technology student.  I am working on an independent project to design and produce an inexpensive SynchroPhasor PMU sensor for research and development.  My work with openPDC is developing and testing the interaces and protocols that the PMU sensor will use to interface with openPDC.<br /><br />As of February, 2011, GridTrak Open Source PMU (GTosPMU) kits are now available.  See the <a href="http://gtospmu.codeplex.com/wikipage?title=GridTrak%20Open%20Source%20PMU%20%28GTosPMU%29&amp;referringTitle=Home" rel="nofollow">GridTrak Open Source PMU Project</a>.  <br /><br />For more information about GridTrak Open Source PMU kit details or to purchase kits or assembled sensors, contact me using the link on this page.<br /> <br />//AJ<br /><br />My other resources:<br /><a href="http://wiki.gridtrak.com/wiki/index.php/GridTrak" rel="nofollow">GridTrak Project</a><br />
-</div>
-<div id="footer">
-<hr />
-Extracted Oct 10, 2015 from <a href="http://www.codeplex.com/site/users/view/ajstadlin">ajstadlin@CodePlex</a>
-</div>
-</body>
-</html>
+[![The Open Source Phasor Data Concentrator](../openPDC_Logo.png)](../openPDC_Home.md)
+
+|   |   |   |   |
+|---|---|---|---|
+| **[Grid Protection Alliance](http://www.gridprotectionalliance.org)** | **[openPDC Project on GitHub](https://github.com/GridProtectionAlliance/openPDC)** | **[openPDC Wiki Home](../openPDC_Home.md)** | **[Documentation](../openPDC_Documentation_Home.md)** |
+
+# Contributor - ajstadlin
+![ajstadlin](ajstadlin.png)
+
+### Personal Statement
+
+I am a full time systems administrator, software engineer, and electronics technology enthusiast.  I developed an independent project to design and produce the [GridTrak Open Source PMU](https://github.com/ajstadlin/GridTrak) an inexpensive SynchroPhasor PMU sensor for research and development.  
+
+My interest in openPDC is developing and testing the interaces and protocols that the PMU sensor will use to interface with openPDC.  I also edit some of the openPDC project documentation.
+
+//AJ
+
+[GridTrak Open Source PMU Project on GitHub](https://github.com/ajstadlin/GridTrak)
+
+---
+* Updated Nov 9, 2016 [//aj](https://github.com/ajstadlin)
+* Extracted Oct 10, 2015 from [ajstadlin@CodePlex](http://www.codeplex.com/site/users/view/ajstadlin)
 
 

--- a/Source/Documentation/wiki/Contributors/alexfoglia.md
+++ b/Source/Documentation/wiki/Contributors/alexfoglia.md
@@ -1,34 +1,13 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" class="">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Contributor - alexfoglia</title>
-<meta content="alexfoglia" property="profile:username" />
-</head>
-<body>
-<!--HtmlToGmd.Body-->
-<h1>
-<a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md"><img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/openPDC_Logo.png" alt="The Open Source Phasor Data Concentrator" /></a></h1>
-<div id="NavigationMenu">
-<table style="width: 100%; border-collapse: collapse; border: 0px solid gray;">
-<tr>
-<td style="width: 25%; text-align:center;"><b><a href="http://www.gridprotectionalliance.org">Grid Protection Alliance</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC">openPDC Project on GitHub</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md">openPDC Wiki Home</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Documentation_Home.md">Documentation</a></b></td>
-</tr>
-</table>
-</div>
-<hr />
-<!--/HtmlToGmd.Body-->
-<img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/Contributors/codeplex.png" alt="alexfoglia" /><br />
-<h2 class="user_name" style="display: inline">alexfoglia</h2>
-<h3>Personal Statement</h3>
-<div class="WikiContent" id="WikiContentDiv">
-No personal statement has been written.<br />
-</div>
-<div id="footer">
-<hr />
-Extracted Oct 10, 2015 from <a href="http://www.codeplex.com/site/users/view/alexfoglia">alexfoglia@CodePlex</a>
-</div>
-</body>
-</html>
+[![The Open Source Phasor Data Concentrator](../openPDC_Logo.png)](../openPDC_Home.md)
+
+|   |   |   |   |
+|---|---|---|---|
+| **[Grid Protection Alliance](http://www.gridprotectionalliance.org)** | **[openPDC Project on GitHub](https://github.com/GridProtectionAlliance/openPDC)** | **[openPDC Wiki Home](../openPDC_Home.md)** | **[Documentation](../openPDC_Documentation_Home.md)** |
+
+# Contributor - alexfoglia
+
+![alexfoglia](codeplex.png)
+
+---
+
+* Extracted Oct 10, 2015 from [alexfoglia@CodePlex](http://www.codeplex.com/site/users/view/alexfoglia)

--- a/Source/Documentation/wiki/Contributors/arkrohne.md
+++ b/Source/Documentation/wiki/Contributors/arkrohne.md
@@ -1,34 +1,13 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" class="">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Contributor - arkrohne</title>
-<meta content="alexfoglia" property="profile:username" />
-</head>
-<body>
-<!--HtmlToGmd.Body-->
-<h1>
-<a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md"><img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/openPDC_Logo.png" alt="The Open Source Phasor Data Concentrator" /></a></h1>
-<div id="NavigationMenu">
-<table style="width: 100%; border-collapse: collapse; border: 0px solid gray;">
-<tr>
-<td style="width: 25%; text-align:center;"><b><a href="http://www.gridprotectionalliance.org">Grid Protection Alliance</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC">openPDC Project on GitHub</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md">openPDC Wiki Home</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Documentation_Home.md">Documentation</a></b></td>
-</tr>
-</table>
-</div>
-<hr />
-<!--/HtmlToGmd.Body-->
-<img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/Contributors/codeplex.png" alt="arkrohne" /><br />
-<h2 class="user_name" style="display: inline">arkrohne</h2>
-<h3>Personal Statement</h3>
-<div class="WikiContent" id="WikiContentDiv">
-No personal statement has been written.<br />
-</div>
-<div id="footer">
-<hr />
-Extracted Oct 10, 2015 from <a href="http://www.codeplex.com/site/users/view/arkrohne">arkrohne@CodePlex</a>
-</div>
-</body>
-</html>
+[![The Open Source Phasor Data Concentrator](../openPDC_Logo.png)](../openPDC_Home.md)
+
+|   |   |   |   |
+|---|---|---|---|
+| **[Grid Protection Alliance](http://www.gridprotectionalliance.org)** | **[openPDC Project on GitHub](https://github.com/GridProtectionAlliance/openPDC)** | **[openPDC Wiki Home](../openPDC_Home.md)** | **[Documentation](../openPDC_Documentation_Home.md)** |
+
+# Contributor - arkrohne
+
+![arkrohne](codeplex.png)
+
+---
+
+* Extracted Oct 10, 2015 from [arkrohne@CodePlex](http://www.codeplex.com/site/users/view/arkrohne)

--- a/Source/Documentation/wiki/Contributors/avinash_e.md
+++ b/Source/Documentation/wiki/Contributors/avinash_e.md
@@ -1,34 +1,14 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" class="">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Contributor - avinash_e</title>
 <meta content="avinash_e" property="profile:username" />
-</head>
-<body>
-<!--HtmlToGmd.Body-->
-<h1>
-<a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md"><img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/openPDC_Logo.png" alt="The Open Source Phasor Data Concentrator" /></a></h1>
-<div id="NavigationMenu">
-<table style="width: 100%; border-collapse: collapse; border: 0px solid gray;">
-<tr>
-<td style="width: 25%; text-align:center;"><b><a href="http://www.gridprotectionalliance.org">Grid Protection Alliance</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC">openPDC Project on GitHub</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md">openPDC Wiki Home</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Documentation_Home.md">Documentation</a></b></td>
-</tr>
-</table>
-</div>
-<hr />
-<!--/HtmlToGmd.Body-->
-<img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/Contributors/codeplex.png" alt="avinash_e" /><br />
-<h2 class="user_name" style="display: inline">avinash_e</h2>
-<h3>Personal Statement</h3>
-<div class="WikiContent" id="WikiContentDiv">
-No personal statement has been written.<br />
-</div>
-<div id="footer">
-<hr />
-Extracted Oct 10, 2015 from <a href="http://www.codeplex.com/site/users/view/avinash_e">avinash_e@CodePlex</a>
-</div>
-</body>
-</html>
+[![The Open Source Phasor Data Concentrator](../openPDC_Logo.png)](../openPDC_Home.md)
+
+|   |   |   |   |
+|---|---|---|---|
+| **[Grid Protection Alliance](http://www.gridprotectionalliance.org)** | **[openPDC Project on GitHub](https://github.com/GridProtectionAlliance/openPDC)** | **[openPDC Wiki Home](../openPDC_Home.md)** | **[Documentation](../openPDC_Documentation_Home.md)** |
+
+# Contributor - avinash_e
+
+![avinash_e](codeplex.png)
+
+---
+
+* Extracted Oct 10, 2015 from [avinash_e@CodePlex](http://www.codeplex.com/site/users/view/avinash_e)

--- a/Source/Documentation/wiki/Contributors/jmartinbeg.md
+++ b/Source/Documentation/wiki/Contributors/jmartinbeg.md
@@ -1,34 +1,19 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" class="">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Contributor - jmartinbeg</title>
-<meta content="jmartinbeg" property="profile:username" />
-</head>
-<body>
-<!--HtmlToGmd.Body-->
-<h1>
-<a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md"><img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/openPDC_Logo.png" alt="The Open Source Phasor Data Concentrator" /></a></h1>
-<div id="NavigationMenu">
-<table style="width: 100%; border-collapse: collapse; border: 0px solid gray;">
-<tr>
-<td style="width: 25%; text-align:center;"><b><a href="http://www.gridprotectionalliance.org">Grid Protection Alliance</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC">openPDC Project on GitHub</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md">openPDC Wiki Home</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Documentation_Home.md">Documentation</a></b></td>
-</tr>
-</table>
-</div>
-<hr />
-<!--/HtmlToGmd.Body-->
-<img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/Contributors/codeplex.png" alt="jmartinbeg" /><br />
-<h2 class="user_name" style="display: inline">jmartinbeg</h2>
-<h3>Personal Statement</h3>
-<div class="WikiContent" id="WikiContentDiv">
-I am drawn to real time problems and how one might employ technology to explore them.<br />I own www.morningglorytech.com home of Remote Batch Copy and Active IP Sensor but both are very old by now. I study C37 networks and their possibilities most of the time now and would like very much to continue in this field.<br />
-</div>
-<div id="footer">
-<hr />
-Extracted Oct 10, 2015 from <a href="http://www.codeplex.com/site/users/view/jmartinbeg">jmartinbeg@CodePlex</a>
-</div>
-</body>
-</html>
+[![The Open Source Phasor Data Concentrator](../openPDC_Logo.png)](../openPDC_Home.md)
+
+|   |   |   |   |
+|---|---|---|---|
+| **[Grid Protection Alliance](http://www.gridprotectionalliance.org)** | **[openPDC Project on GitHub](https://github.com/GridProtectionAlliance/openPDC)** | **[openPDC Wiki Home](../openPDC_Home.md)** | **[Documentation](../openPDC_Documentation_Home.md)** |
+
+# Contributor - jmartinbeg
+
+![](codeplex.png)
+
+### Personal Statement
+
+I am drawn to real time problems and how one might employ technology to explore them.
+
+I own www.morningglorytech.com home of Remote Batch Copy and Active IP Sensor but both are very old by now. I study C37 networks and their possibilities most of the time now and would like very much to continue in this field.
+
+---
+
+* Extracted Oct 10, 2015 from [jmartinbeg@CodePlex](http://www.codeplex.com/site/users/view/jmartinbeg)

--- a/Source/Documentation/wiki/Contributors/kevinjones.md
+++ b/Source/Documentation/wiki/Contributors/kevinjones.md
@@ -1,34 +1,17 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" class="">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Contributor - kevinjones</title>
-<meta content="kevinjones" property="profile:username" />
-</head>
-<body>
-<!--HtmlToGmd.Body-->
-<h1>
-<a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md"><img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/openPDC_Logo.png" alt="The Open Source Phasor Data Concentrator" /></a></h1>
-<div id="NavigationMenu">
-<table style="width: 100%; border-collapse: collapse; border: 0px solid gray;">
-<tr>
-<td style="width: 25%; text-align:center;"><b><a href="http://www.gridprotectionalliance.org">Grid Protection Alliance</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC">openPDC Project on GitHub</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md">openPDC Wiki Home</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Documentation_Home.md">Documentation</a></b></td>
-</tr>
-</table>
-</div>
-<hr />
-<!--/HtmlToGmd.Body-->
-<img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/Contributors/kevinjones.png" alt="kevinjones" /><br />
-<h2 class="user_name" style="display: inline">kevinjones</h2>
-<h3>Personal Statement</h3>
-<div class="WikiContent" id="WikiContentDiv">
-<a href="https://www.linkedin.com/pub/kevin-jones/b8/b39/701" rel="nofollow">Kevin&#39;s LinkedIn Profile</a><br />
-</div>
-<div id="footer">
-<hr />
-Extracted Oct 10, 2015 from <a href="http://www.codeplex.com/site/users/view/kevinjones">kevinjones@CodePlex</a>
-</div>
-</body>
-</html>
+[![The Open Source Phasor Data Concentrator](../openPDC_Logo.png)](../openPDC_Home.md)
+
+|   |   |   |   |
+|---|---|---|---|
+| **[Grid Protection Alliance](http://www.gridprotectionalliance.org)** | **[openPDC Project on GitHub](https://github.com/GridProtectionAlliance/openPDC)** | **[openPDC Wiki Home](../openPDC_Home.md)** | **[Documentation](../openPDC_Documentation_Home.md)** |
+
+# Contributor - kevinjones
+
+![kevinjones](kevinjones.png)
+
+### Personal Statement
+
+[Kevin&#39;s LinkedIn Profile](https://www.linkedin.com/pub/kevin-jones/b8/b39/701)
+
+---
+
+* Extracted Oct 10, 2015 from [kevinjones@CodePlex](http://www.codeplex.com/site/users/view/kevinjones)

--- a/Source/Documentation/wiki/Contributors/patpentz.md
+++ b/Source/Documentation/wiki/Contributors/patpentz.md
@@ -1,34 +1,13 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" class="">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Contributor - patpentz</title>
-<meta content="patpentz" property="profile:username" />
-</head>
-<body>
-<!--HtmlToGmd.Body-->
-<h1>
-<a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md"><img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/openPDC_Logo.png" alt="The Open Source Phasor Data Concentrator" /></a></h1>
-<div id="NavigationMenu">
-<table style="width: 100%; border-collapse: collapse; border: 0px solid gray;">
-<tr>
-<td style="width: 25%; text-align:center;"><b><a href="http://www.gridprotectionalliance.org">Grid Protection Alliance</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC">openPDC Project on GitHub</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md">openPDC Wiki Home</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Documentation_Home.md">Documentation</a></b></td>
-</tr>
-</table>
-</div>
-<hr />
-<!--/HtmlToGmd.Body-->
-<img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/Contributors/codeplex.png" alt="patpentz" /><br />
-<h2 class="user_name" style="display: inline">patpentz</h2>
-<h3>Personal Statement</h3>
-<div class="WikiContent" id="WikiContentDiv">
-No personal statement has been written.<br />
-</div>
-<div id="footer">
-<hr />
-Extracted Oct 10, 2015 from <a href="http://www.codeplex.com/site/users/view/patpentz">arkrohne@CodePlex</a>
-</div>
-</body>
-</html>
+[![The Open Source Phasor Data Concentrator](../openPDC_Logo.png)](../openPDC_Home.md)
+
+|   |   |   |   |
+|---|---|---|---|
+| **[Grid Protection Alliance](http://www.gridprotectionalliance.org)** | **[openPDC Project on GitHub](https://github.com/GridProtectionAlliance/openPDC)** | **[openPDC Wiki Home](../openPDC_Home.md)** | **[Documentation](../openPDC_Documentation_Home.md)** |
+
+# Contributor - patpentz
+
+![patpentz](codeplex.png)
+
+---
+
+* Extracted Oct 10, 2015 from [patpentz@CodePlex](http://www.codeplex.com/site/users/view/patpentz)

--- a/Source/Documentation/wiki/Contributors/priyankarjk.md
+++ b/Source/Documentation/wiki/Contributors/priyankarjk.md
@@ -1,34 +1,13 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" class="">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Contributor - priyankarjk</title>
-<meta content="priyankarjk" property="profile:username" />
-</head>
-<body>
-<!--HtmlToGmd.Body-->
-<h1>
-<a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md"><img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/openPDC_Logo.png" alt="The Open Source Phasor Data Concentrator" /></a></h1>
-<div id="NavigationMenu">
-<table style="width: 100%; border-collapse: collapse; border: 0px solid gray;">
-<tr>
-<td style="width: 25%; text-align:center;"><b><a href="http://www.gridprotectionalliance.org">Grid Protection Alliance</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC">openPDC Project on GitHub</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md">openPDC Wiki Home</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Documentation_Home.md">Documentation</a></b></td>
-</tr>
-</table>
-</div>
-<hr />
-<!--/HtmlToGmd.Body-->
-<img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/Contributors/codeplex.png" alt="priyankarjk" /><br />
-<h2 class="user_name" style="display: inline">priyankarjk</h2>
-<h3>Personal Statement</h3>
-<div class="WikiContent" id="WikiContentDiv">
-No personal statement has been written.<br />
-</div>
-<div id="footer">
-<hr />
-Extracted Oct 10, 2015 from <a href="http://www.codeplex.com/site/users/view/priyankarjk">priyankarjk@CodePlex</a>
-</div>
-</body>
-</html>
+[![The Open Source Phasor Data Concentrator](../openPDC_Logo.png)](../openPDC_Home.md)
+
+|   |   |   |   |
+|---|---|---|---|
+| **[Grid Protection Alliance](http://www.gridprotectionalliance.org)** | **[openPDC Project on GitHub](https://github.com/GridProtectionAlliance/openPDC)** | **[openPDC Wiki Home](../openPDC_Home.md)** | **[Documentation](../openPDC_Documentation_Home.md)** |
+
+# Contributor - priyankarjk
+
+![priyankarjk](codeplex.png)
+
+---
+
+* Extracted Oct 10, 2015 from [priyankarjk@CodePlex](http://www.codeplex.com/site/users/view/priyankarjk)

--- a/Source/Documentation/wiki/Contributors/ritchiecarroll.md
+++ b/Source/Documentation/wiki/Contributors/ritchiecarroll.md
@@ -1,34 +1,17 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" class="">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Contributor - ritchiecarroll</title>
-<meta content="ritchiecarroll" property="profile:username" />
-</head>
-<body>
-<!--HtmlToGmd.Body-->
-<h1>
-<a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md"><img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/openPDC_Logo.png" alt="The Open Source Phasor Data Concentrator" /></a></h1>
-<div id="NavigationMenu">
-<table style="width: 100%; border-collapse: collapse; border: 0px solid gray;">
-<tr>
-<td style="width: 25%; text-align:center;"><b><a href="http://www.gridprotectionalliance.org">Grid Protection Alliance</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC">openPDC Project on GitHub</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md">openPDC Wiki Home</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Documentation_Home.md">Documentation</a></b></td>
-</tr>
-</table>
-</div>
-<hr />
-<!--/HtmlToGmd.Body-->
-<img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/Contributors/ritchiecarroll.png" alt="ritchiecarroll" /><br />
-<h2 class="user_name" style="display: inline">ritchiecarroll</h2>
-<h3>Personal Statement</h3>
-<div class="WikiContent" id="WikiContentDiv">
-<i>Always look towards the future with hope and anticipation!</i><br />
-</div>
-<div id="footer">
-<hr />
-Extracted Oct 10, 2015 from <a href="http://www.codeplex.com/site/users/view/ritchiecarroll">ritchiecarroll@CodePlex</a>
-</div>
-</body>
-</html>
+[![The Open Source Phasor Data Concentrator](../openPDC_Logo.png)](../openPDC_Home.md)
+
+|   |   |   |   |
+|---|---|---|---|
+| **[Grid Protection Alliance](http://www.gridprotectionalliance.org)** | **[openPDC Project on GitHub](https://github.com/GridProtectionAlliance/openPDC)** | **[openPDC Wiki Home](../openPDC_Home.md)** | **[Documentation](../openPDC_Documentation_Home.md)** |
+
+# Contributor - ritchiecarroll
+
+![ritchiecarroll](ritchiecarroll.png)
+
+### Personal Statement
+
+*Always look towards the future with hope and anticipation!*
+
+---
+
+* Extracted Oct 10, 2015 from [ritchiecarroll@CodePlex](http://www.codeplex.com/site/users/view/ritchiecarroll)

--- a/Source/Documentation/wiki/Contributors/rrobertson.md
+++ b/Source/Documentation/wiki/Contributors/rrobertson.md
@@ -1,36 +1,14 @@
+[![The Open Source Phasor Data Concentrator](../openPDC_Logo.png)](../openPDC_Home.md)
 
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" class="">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Contributor - rrobertson</title>
-<meta content="rrobertson" property="profile:username" />
-</head>
-<body>
-<!--HtmlToGmd.Body-->
-<h1>
-<a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md"><img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/openPDC_Logo.png" alt="The Open Source Phasor Data Concentrator" /></a></h1>
-<div id="NavigationMenu">
-<table style="width: 100%; border-collapse: collapse; border: 0px solid gray;">
-<tr>
-<td style="width: 25%; text-align:center;"><b><a href="http://www.gridprotectionalliance.org">Grid Protection Alliance</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC">openPDC Project on GitHub</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md">openPDC Wiki Home</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Documentation_Home.md">Documentation</a></b></td>
-</tr>
-</table>
-</div>
-<hr />
-<!--/HtmlToGmd.Body-->
-<img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/Contributors/codeplex.png" alt="rrobertson" /><br />
-<h2 class="user_name" style="display: inline">rrobertson</h2>
-<h3>Personal Statement</h3>
-<div class="WikiContent" id="WikiContentDiv">
-No personal statement has been written.<br />
-</div>
-<div id="footer">
-<hr />
-Extracted Oct 10, 2015 from <a href="http://www.codeplex.com/site/users/view/rrobertson">rrobertson@CodePlex</a>
-</div>
-</body>
-</html>
+|   |   |   |   |
+|---|---|---|---|
+| **[Grid Protection Alliance](http://www.gridprotectionalliance.org)** | **[openPDC Project on GitHub](https://github.com/GridProtectionAlliance/openPDC)** | **[openPDC Wiki Home](../openPDC_Home.md)** | **[Documentation](../openPDC_Documentation_Home.md)** |
+
+# Contributor - rrobertson
+
+![rrobertson](codeplex.png)
+
+---
+
+* Extracted Oct 10, 2015 from [rrobertson@CodePlex](http://www.codeplex.com/site/users/view/rrobertson)
 

--- a/Source/Documentation/wiki/Contributors/staphen.md
+++ b/Source/Documentation/wiki/Contributors/staphen.md
@@ -1,34 +1,13 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" class="">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Contributor - staphen</title>
-<meta content="staphen" property="profile:username" />
-</head>
-<body>
-<!--HtmlToGmd.Body-->
-<h1>
-<a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md"><img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/openPDC_Logo.png" alt="The Open Source Phasor Data Concentrator" /></a></h1>
-<div id="NavigationMenu">
-<table style="width: 100%; border-collapse: collapse; border: 0px solid gray;">
-<tr>
-<td style="width: 25%; text-align:center;"><b><a href="http://www.gridprotectionalliance.org">Grid Protection Alliance</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC">openPDC Project on GitHub</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md">openPDC Wiki Home</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Documentation_Home.md">Documentation</a></b></td>
-</tr>
-</table>
-</div>
-<hr />
-<!--/HtmlToGmd.Body-->
-<img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/Contributors/codeplex.png" alt="staphen" /><br />
-<h2 class="user_name" style="display: inline">staphen</h2>
-<h3>Personal Statement</h3>
-<div class="WikiContent" id="WikiContentDiv">
-No personal statement has been written.<br />
-</div>
-<div id="footer">
-<hr />
-Extracted Oct 10, 2015 from <a href="http://www.codeplex.com/site/users/view/staphen">staphen@CodePlex</a>
-</div>
-</body>
-</html>
+[![The Open Source Phasor Data Concentrator](../openPDC_Logo.png)](../openPDC_Home.md)
+
+|   |   |   |   |
+|---|---|---|---|
+| **[Grid Protection Alliance](http://www.gridprotectionalliance.org)** | **[openPDC Project on GitHub](https://github.com/GridProtectionAlliance/openPDC)** | **[openPDC Wiki Home](../openPDC_Home.md)** | **[Documentation](../openPDC_Documentation_Home.md)** |
+
+# Contributor - staphen
+
+![staphen](codeplex.png)
+
+---
+
+* Extracted Oct 10, 2015 from [staphen@CodePlex](http://www.codeplex.com/site/users/view/staphen)


### PR DESCRIPTION
Documents converted from HTML to Markdown.  These documents are in a subfolder off the project wiki root.  The headings in these documents differ from the root documents.  They contain relative ../parent links.  This works in github markdown.  I will be using these for testing github markdown to dokuwiki conversion process.

No merge conflicts expected.