### PR TITLE
wiki/Data_Quality_Monitoring/DataView_RowFilter_Syntax.md code highlighting fixed

### DIFF
--- a/Source/Documentation/wiki/Data_Quality_Monitoring.files/DataView_RowFilter_Syntax.md
+++ b/Source/Documentation/wiki/Data_Quality_Monitoring.files/DataView_RowFilter_Syntax.md
@@ -18,7 +18,7 @@ If a column name contains any of these special characters:
 you must enclose the column name within square brackets `[ ]`.  If a column name contains right bracket `]` or backslash `\`, escape it with backslash: `\]` or `\\`.
 
 
-```C#
+```cs
 dataView.RowFilter = "id = 10";         // no special character in column name "id"
 dataView.RowFilter = "$id = 10";        // no special character in column name "$id"
 dataView.RowFilter = "[#id] = 10";      // special character "#" in column name "#id"
@@ -29,7 +29,7 @@ dataView.RowFilter = "[[id\]] = 10";    // special characters in column name "[i
 
 **String values** are enclosed within single quotes `' '`.  If the string contains single quote `'`, the quote must be doubled.
 
-```C#
+```cs
 dataView.RowFilter = "Name = 'John'";               // string value
 dataView.RowFilter = "Name = 'John ''A''";          // string with single quotes "John 'A'"
 dataView.RowFilter = String.Format("Name = '{0}'", "John 'A'".Replace("'", "''"));
@@ -37,7 +37,7 @@ dataView.RowFilter = String.Format("Name = '{0}'", "John 'A'".Replace("'", "''")
 
 **Number values** are not enclosed within any characters.  The values should be the same as is the result of `int.ToString()` or `float.ToString()` method for invariant or English culture.
 
-```C#
+```cs
 dataView.RowFilter = "Year = 2008";                 // integer value
 dataView.RowFilter = "Price = 1199.9";              // float value
 
@@ -46,7 +46,7 @@ dataView.RowFilter = String.Format(CultureInfo.InvariantCulture.NumberFormat, "P
 
 **Date values** are enclosed within sharp characters `# #`.  The date format is the same as is the result of `DateTime.ToString()` method for invariant or English culture.
 
-```C#
+```cs
 dataView.RowFilter = "Date = #12/31/2008#";             // date value (time is 00:00:00)
 dataView.RowFilter = "Date = #2008-12-31#";             // also this format is supported
 dataView.RowFilter = "Date = #12/31/2008 16:44:58#";    // date and time value
@@ -56,7 +56,7 @@ dataView.RowFilter = String.Format(CultureInfo.InvariantCulture.DateTimeFormat, 
 
 **Alternatively** you can enclose all values within single quotes `' '`.  It means you can **use string values** for numbers or date time values.  In this case the current culture is used to convert the string to the specific value.
 
-```C#
+```cs
 dataView.RowFilter = "Date = '12/31/2008 16:44:58'";    // if current culture is English
 dataView.RowFilter = "Date = '31.12.2008 16:44:58'";    // if current culture is German
 
@@ -73,7 +73,7 @@ dataView.RowFilter = "Price = '1199,90'";               // if current culture is
 
 Note:  **String comparison** is **culture-sensitive**, it uses CultureInfo from [DataTable.Locale](http://msdn2.microsoft.com/en-us/library/system.data.datatable.locale.aspx) property of related `dataView.Table.Locale`.  If the property is not explicitly set, its default value is `DataSet.Locale` (and its default value is current system culture `Thread.CurrentThread.CurrentCulture`.
 
-```C#
+```cs
 dataView.RowFilter = "Num = 10";                // number is equal to 10
 dataView.RowFilter = "Date < #1/1/2008#";       // date is less than 1/1/2008
 DataView.RowFilter = "Name <> 'John'";          // string is not equal to 'John'
@@ -82,7 +82,7 @@ dataView.RowFilter = "Name >= 'Jo'"             // string comparison
 
 **Operator IN** is used to include only values from the list.  You can use the operator for all data types, such as numbers or strings.
 
-```C#
+```cs
 dataView.RowFilter = "Id IN (1, 2, 3)";                     // integer values
 dataView.RowFilter = "Price IN (1.0, 9.9, 11.5)";           // float values
 dataView.RowFilter = "Name IN ('John', 'Jim', 'Tom')";      // string values
@@ -92,7 +92,7 @@ dataView.RowFilter = "Id NOT IN (1, 2, 3)";                 // values not from t
 
 **Operator LIKE** is used to include only values that match a pattern with wildcards. **Wildcard** character is `*` or `%`, it can be at the beginning of a pattern `'*value'`, at the end `'value*'`, or at both `'*value*'`.  Wildcard in the middle of a patern `'va*lue'` is **not allowed**.
 
-```C#
+```cs
 dataView.RowFilter = "Name LIKE 'j*'";              // values that start with 'j'
 dataView.RowFilter = "Name LIKE '%jo%'";            // values that contain 'jo'
 dataView.RowFilter = "Name NOT LIKE 'j*'";          // values that don't start with 'j'
@@ -101,14 +101,14 @@ dataView.RowFilter = "Name NOT LIKE 'j*'";          // values that don't start w
 If a pattern in a LIKE clause contains any of these special characters `* % [ ]`, those characters must be escaped in brackets `[ ]` like this
 `[*]`, `[%]`, `[[]` or `[]]`.
 
-```C#
+```cs
 dataView.RowFilter = "Name LIKE '[*]*'";                // values that starts with '*'
 dataView.RowFilter = "Name LIKE '[[]*'";                // values that starts with '['
 ```
 
 The following method escapes a text value for usage in a LIKE clause.
 
-```C#
+```cs
 public static string EscapeLikeValue(string valueWithoutWildcards)
 {
     StringBuilder sb = new StringBuilder();
@@ -126,7 +126,7 @@ public static string EscapeLikeValue(string valueWithoutWildcards)
 }
 ```
 
-```C#
+```cs
 // select all that starts with the value string (in this case with "*")
 string value = "*";
 // the dataView.RowFilter will be: "Name LIKE '[*]*'"
@@ -137,7 +137,7 @@ dataView.RowFilter = String.Format("Name LIKE '{0}*'", EscapeLikeValue(value));
 
 Boolean operators `AND`, `OR`, and `NOT` are used to concatenate expressions. Operator NOT has precedence over AND operator and it has precedence over OR operator.
 
-```C#
+```cs
 // operator AND has precedence over OR operator, parenthesis are needed
 dataView.RowFilter = "City = 'Tokyo' AND (Age < 20 OR Age > 60)";
 
@@ -152,7 +152,7 @@ dataView.RowFilter = "City NOT IN ('Tokyo', 'Paris')";
 
 **Arithmetic operators** are addition `+`, subtraction `-`, multiplication `*`, division `/` and modulus `%`.
 
-```C#
+```cs
 dataView.RowFilter = "MotherAge - Age < 20";        // people with young mother</span>
 dataView.RowFilter = "Age % 10 = 0";                // people with decennial birthday
 ```
@@ -173,7 +173,7 @@ There are supported following aggregate functions `SUM`, `COUNT`, `MIN`, `MAX`, 
 
 This example shows aggregate function performed on a single table.
 
-```C#
+```cs
 // select people with above-average salary
 dataView.RowFilter = "Salary > AVG(Salary)";
 ```
@@ -181,7 +181,7 @@ dataView.RowFilter = "Salary > AVG(Salary)";
 Following example shows aggregate functions performed on two tables which have parent-child relation. Suppose there are tables Orders and Items with the
 parent-child relation.
 
-```C#
+```cs
 // select orders which have more than 5 items
 dataView.RowFilter = "COUNT(Child.IdOrder) > 5";
 


### PR DESCRIPTION
C# code syntax high-lighting fixed.  Need to use _cs_ instead of _C#_

No information content changed.
No merge conflicts expected.