### PR TITLE
wiki/Developers docs markdown conversions and fixups, 6 files

### DIFF
--- a/Source/Documentation/wiki/DeveloperPath.md
+++ b/Source/Documentation/wiki/DeveloperPath.md
@@ -75,10 +75,12 @@ If you have been granted developer access, please adhere to the following rules:
 
 Note that some of the rules could be enforced by TFS but the codeplex TFS is a shared system, so for now we are simply using the honor system.
 
----  
-Nov 25, 2016 22:00 Updated by [aj](https://github.com/ajstadlin), version 5  
-Oct 4, 2009 11:17 Edited by [ritchiecarroll](https://github.com/ritchiecarroll), version 4  
-Oct 4, 2015 Migrated from [CodePlex](http://openpdc.codeplex.com/wikipage?title=DeveloperPath) by [aj](https://github.com/ajstadlin)
+---
 
----  
+Nov 25, 2016 22:00 - Updated by [aj](https://github.com/ajstadlin), version 5  
+Oct 4, 2009 11:17 - Edited by [ritchiecarroll](https://github.com/ritchiecarroll), version 4  
+Oct 4, 2015 - Migrated from [CodePlex](http://openpdc.codeplex.com/wikipage?title=DeveloperPath) by [aj](https://github.com/ajstadlin)
+
+---
+
 Copyright 2015 [Grid Protection Alliance](http://www.gridprotectionalliance.org)

--- a/Source/Documentation/wiki/Developers_About_the_Code.md
+++ b/Source/Documentation/wiki/Developers_About_the_Code.md
@@ -3484,8 +3484,9 @@ SEL Fast Message status word flags enumeration.
 [Click for larger image](Developers_About_the_Code.files/Phasor_Value_Relationships.jpg)
 
 ---  
-- Jun 22, 2012 13:52:42 Last edited by [alexfoglia](Contributors/alexfoglia.md), version 5  
-- Oct 5, 2015 Migrated from [CodePlex](http://openpdc.codeplex.com/wikipage?title=About%20the%20Code%20%28Developers%29) by [aj](https://github.com/ajstadlin)
+
+Jun 22, 2012 13:52:42 - Last edited by [alexfoglia](Contributors/alexfoglia.md), version 5  
+Oct 5, 2015 - Migrated from [CodePlex](http://openpdc.codeplex.com/wikipage?title=About%20the%20Code%20%28Developers%29) by [aj](https://github.com/ajstadlin)
 
 ---  
 Copyright 2015 [Grid Protection Alliance](http://www.gridprotectionalliance.org)

--- a/Source/Documentation/wiki/Developers_About_the_Signal_Reference.md
+++ b/Source/Documentation/wiki/Developers_About_the_Signal_Reference.md
@@ -53,8 +53,8 @@ Using this information you can map individual measurements to and from most any 
 
 ---
 
-Apr 12, 2013 at 5:55:03 PM Last edited by [ritchiecarroll](https://github.com/ritchiecarroll), version 7  
-Oct 5, 2015 Migrated from [CodePlex](http://openpdc.codeplex.com/wikipage?title=About%20the%20Signal%20Reference) by [aj](https://github.com/ajstadlin)
+Apr 12, 2013 at 5:55:03 PM - Last edited by [ritchiecarroll](https://github.com/ritchiecarroll), version 7  
+Oct 5, 2015 - Migrated from [CodePlex](http://openpdc.codeplex.com/wikipage?title=About%20the%20Signal%20Reference) by [aj](https://github.com/ajstadlin)
 
 ---
 

--- a/Source/Documentation/wiki/Developers_Automated_Phasor_Tag_Naming_Convention.md
+++ b/Source/Documentation/wiki/Developers_Automated_Phasor_Tag_Naming_Convention.md
@@ -67,10 +67,10 @@ In a semi-formal summary, the following is the format the openPDC uses for its a
 
 ---
 
-|     |
-| --- |
-| Aug 7, 2013 at 5:07 PM Last edited  by [ritchiecarroll](https://github.com/ritchiecarroll), version 6 |
-| Oct 5, 2015 Migrated from [CodePlex](http://openpdc.codeplex.com/wikipage?title=Automated%20Phasor%20Tag%20Naming%20Convention) by [aj](https://github.com/ajstadlin) |
-|     | 
-| Copyright 2015 [Grid Protection Alliance](http://www.gridprotectionalliance.org) |
+Aug 7, 2013 at 5:07 PM - Last edited  by [ritchiecarroll](https://github.com/ritchiecarroll), version 6  
+Oct 5, 2015 - Migrated from [CodePlex](http://openpdc.codeplex.com/wikipage?title=Automated%20Phasor%20Tag%20Naming%20Convention) by [aj](https://github.com/ajstadlin)
+
+---
+
+Copyright 2015 [Grid Protection Alliance](http://www.gridprotectionalliance.org) |
 

--- a/Source/Documentation/wiki/Developers_Build_the_openPDC_Manager.md
+++ b/Source/Documentation/wiki/Developers_Build_the_openPDC_Manager.md
@@ -1,63 +1,36 @@
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta charset="utf-8" />
-</head>
-<body>
-<!--HtmlToGmd.Body-->
-<h1><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md"><img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/openPDC_Logo.png" alt="The Open Source Phasor Data Concentrator" /></a></h1>
-<hr />
-<div id="NavigationMenu">
-<table style="width: 100%; border-collapse: collapse; border: 0px solid gray;">
-<tr>
-<td style="width: 25%; text-align:center;"><b><a href="http://www.gridprotectionalliance.org">Grid Protection Alliance</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC">openPDC Project on GitHub</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md">openPDC Wiki Home</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Documentation_Home.md">Documentation</a></b></td>
-</tr>
-</table>
-</div>
-<hr />
-<!--/HtmlToGmd.Body-->
-<div class="WikiContent">
-<div class="wikidoc">
-<h1>Build the openPDC Manager</h1>
-<ul>
-<li><a href="#installation">Installation</a> <br>
-<ul>
-<li><a href="#building_from_source">Building from source code</a> </li></ul>
-</li></ul>
-<hr>
-<h2><a name="installation"></a>Installation</h2>
-<h3><a name="building_from_source"></a>Building from source code</h3>
-<p>In order to build the openPDC Manager, you will need to follow the steps for building the openPDC described on the
-<a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/Developers_Getting_Started.md">
-Getting Started</a> page. Additionally, you will also need to install both of the following.</p>
-<ul>
-<li><a href="http://www.microsoft.com/downloads/details.aspx?familyid=9442b0f2-7465-417a-88f3-5e7b5409e9dd&displaylang=en">Silverlight 3 Tools for Visual Studio 2008 SP1</a>
-</li><li><a href="http://silverlight.codeplex.com/Release/ProjectReleases.aspx?ReleaseId=24246">Silverlight 3 Toolkit July 2009</a>
-</li></ul>
-<p><br>
-Now follow these steps to rebuild the Synchrophasor solution.</p>
-<ol>
-<li>Navigate to &quot;SOURCEDIR\Synchrophasor\Current Version\Source&quot; (SOURCEDIR is the directory where you extracted the openPDC source code).
-</li><li>Double-click the file &quot;Synchrophasor.sln&quot;. </li><li>In the Visual Studio toolbar, go to &quot;Build &gt; Rebuild Solution&quot;. </li></ol>
-<hr>
-<div id="_mcePaste" style="left:-10000px; top:11190px; width:1px; height:1px; overflow-x:hidden; overflow-y:hidden">
-<pre style="font-family:Consolas; font-size:12; color:black; background:white"><span style="color:green">use&nbsp;of&nbsp;cached&nbsp;configuration&nbsp;during&nbsp;initial&nbsp;connection&nbsp;is&nbsp;allowed&nbsp;when&nbsp;a&nbsp;configuration&nbsp;has&nbsp;not&nbsp;been&nbsp;received&nbsp;within&nbsp;the&nbsp;data&nbsp;loss&nbsp;interval.</span>
-</pre>
-</div>
-</div>
-</div>
-<div id="footer">
-<hr />
-Last edited <span class="smartDate" title="6/20/2012 2:59:26 PM" LocalTimeTicks="1340229566">Jun 20, 2012 at 2:59 PM</span> by <a id="wikiEditByLink" href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/Contributors/alexfoglia.md">alexfoglia</a>, version 2<br />
-Migrated from <a href="http://openpdc.codeplex.com/wikipage?title=Build%20openPDC%20Manager%20%28Developers%29">CodePlex</a> Oct 4, 2015 by <a href="https://github.com/ajstadlin">ajs</a>
-</div>
-<!--HtmlToGmd.Foot-->
-<div id="copyright">
-<hr />
-Copyright 2015 <a href="http://www.gridprotectionalliance.org">Grid Protection Alliance</a>
-</div>
-<!--/HtmlToGmd.Foot-->
-</body>
-</html>
+[![The Open Source Phasor Data Concentrator](openPDC_Logo.png)](openPDC_Home.md)
+
+|   |   |   |   |
+|---|---|---|---|
+| **[Grid Protection Alliance](http://www.gridprotectionalliance.org)** | **[openPDC Project on GitHub](https://github.com/GridProtectionAlliance/openPDC)** | **[openPDC Wiki Home](openPDC_Home.md)** | **[Documentation](openPDC_Documentation_Home.md)** |
+
+# Build the openPDC Manager
+
+- [Installation](#installation)
+- [Building from source code](#building-from-source-code)
+
+---
+
+## Installation
+
+### Building from source code
+
+In order to build the openPDC Manager, you will need to follow the steps for building the openPDC described on the [Developers Getting Started](Developers_Getting_Started.md) page. Additionally, you will also need to install both of the following.
+
+- [Silverlight 3 Tools for Visual Studio 2008 SP1](http://www.microsoft.com/downloads/details.aspx?familyid=9442b0f2-7465-417a-88f3-5e7b5409e9dd&displaylang=en)
+- [Silverlight 3 Toolkit July 2009](http://silverlight.codeplex.com/Release/ProjectReleases.aspx?ReleaseId=24246)
+
+Now follow these steps to rebuild the Synchrophasor solution.
+
+1. Navigate to `SOURCEDIR\Synchrophasor\Current Version\Source` (SOURCEDIR is the directory where you extracted the openPDC source code).
+2. Double-click the file "Synchrophasor.sln"
+3. In the Visual Studio toolbar, go to "Build > Rebuild Solution"
+
+---
+
+Jun 20, 2012 at 2:59:26 PM - Last edited by [alexfoglia](Contributors/alexfoglia.md), version 2  
+Oct 4, 2015 - Migrated from [CodePlex](http://openpdc.codeplex.com/wikipage?title=Build%20openPDC%20Manager%20%28Developers%29)  by [aj](https://github.com/ajstadlin)
+
+---
+
+Copyright 2015 [Grid Protection Alliance](http://www.gridprotectionalliance.org)

--- a/Source/Documentation/wiki/Developers_Code_Change_Notes.md
+++ b/Source/Documentation/wiki/Developers_Code_Change_Notes.md
@@ -1,44 +1,23 @@
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta charset="utf-8" />
-</head>
-<body>
-<!--HtmlToGmd.Body-->
-<h1><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md"><img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/openPDC_Logo.png" alt="The Open Source Phasor Data Concentrator" /></a></h1>
-<hr />
-<div id="NavigationMenu">
-<table style="width: 100%; border-collapse: collapse; border: 0px solid gray;">
-<tr>
-<td style="width: 25%; text-align:center;"><b><a href="http://www.gridprotectionalliance.org">Grid Protection Alliance</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC">openPDC Project on GitHub</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Home.md">openPDC Wiki Home</a></b></td>
-<td style="width: 25%; text-align:center;"><b><a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/openPDC_Documentation_Home.md">Documentation</a></b></td>
-</tr>
-</table>
-</div>
-<hr />
-<!--/HtmlToGmd.Body-->
-<div class="WikiContent">
-<div class="wikidoc">
-<h1>Notes</h1>
-<ul>
-<li>04/30/2010 - <a href="https://github.com/GridProtectionAlliance/openPDC/tree/master/Source/Documentation/wiki/June1.1FeatureList.md">
-June Version 1.1 Feature List Preview</a> </li><li>10/07/2009 - <em><a href="/openPDC/Documentation">SuperPDC is released as open source as the &quot;openPDC&quot;</a></em>&nbsp;&nbsp;
-</li></ul>
-<p><img src="https://github.com/GridProtectionAlliance/openPDC/blob/master/Source/Documentation/wiki/files/ThePoster.jpg" alt="ThePoster" width="800" height="550"></p>
-<h1>&pi;&iota;&sigma;&tau;&iota;&nu; &tau;&epsilon;&tau;&eta;&rho;&eta;&kappa;&alpha;</h1>
-</div>
-</div>
-<div id="footer">
-<hr />
-Last edited <span class="smartDate" title="7/3/2013 4:55:55 PM" LocalTimeTicks="1372895755">Jul 3, 2013 at 4:55 PM</span> by <a id="wikiEditByLink" href="https://github.com/ritchiecarroll">ritchiecarroll</a>, version 5<br />
-Migrated from <a href="http://openpdc.codeplex.com/wikipage?title=Code%20Blog%20%28Developers%29">CodePlex</a> Oct 5, 2015 by <a href="https://github.com/ajstadlin">ajs</a>
-</div>
-<!--HtmlToGmd.Foot-->
-<div id="copyright">
-<hr />
-Copyright 2015 <a href="http://www.gridprotectionalliance.org">Grid Protection Alliance</a>
-</div>
-<!--/HtmlToGmd.Foot-->
-</body>
-</html>
+[![The Open Source Phasor Data Concentrator](openPDC_Logo.png)](openPDC_Home.md)
+
+|   |   |   |   |
+|---|---|---|---|
+| **[Grid Protection Alliance](http://www.gridprotectionalliance.org)** | **[openPDC Project on GitHub](https://github.com/GridProtectionAlliance/openPDC)** | **[openPDC Wiki Home](openPDC_Home.md)** | **[Documentation](openPDC_Documentation_Home.md)** |
+
+# Notes
+
+- 04/30/2010 - [June Version 1.1 Feature List Preview](June1.1FeatureList.md)
+- 10/07/2009 - **SuperPDC is released as open source as the** "***openPDC***"
+
+![](files/ThePoster.jpg "ThePoster")
+
+# &pi;&iota;&sigma;&tau;&iota;&nu; &tau;&epsilon;&tau;&eta;&rho;&eta;&kappa;&alpha;
+
+---
+
+Jul 3, 2013 at 4:55:55 PM - Last edited by [ritchiecarroll](https://github.com/ritchiecarroll), version 5  
+Oct 5, 2015 - Migrated from [CodePlex](http://openpdc.codeplex.com/wikipage?title=Code%20Blog%20%28Developers%29)  by [aj](https://github.com/ajstadlin)
+
+---
+
+Copyright 2015 [Grid Protection Alliance](http://www.gridprotectionalliance.org)


### PR DESCRIPTION
- DeveloperPath.md, fixups
- Developers_About_the_Code.md, fixups
- Developers_About_the_Signal_Reference.md, fixups
- Developers_Automated_Phasor_Tag_Naming_Convention.md, fixups
- Developers_Build_the_openPDC_Manager.md, converted from HTML to GFM
- Developers_Code_Change_Notes.md, converted from HTML to GFM

No content information changes  
No merge conflicts expected  
//AJ
