### PR TITLE
Added docker file and readme

### DIFF
--- a/Source/DockerReadMe.md
+++ b/Source/DockerReadMe.md
@@ -17,7 +17,7 @@ docker tag openpdc gridprotectionalliance/openpdc:v2.9.148
 ```
 
 ### Push Tagged Docker Image to dockerhub
-This push the tagged image `gridprotectionalliance/openpdc:v2.9.148` to dockerhub:
+This pushes the tagged image `gridprotectionalliance/openpdc:v2.9.148` to dockerhub:
 ```sh
 docker push gridprotectionalliance/openpdc:v2.9.148
 ```

--- a/Source/DockerReadMe.md
+++ b/Source/DockerReadMe.md
@@ -1,0 +1,46 @@
+### Build Docker Image
+This builds an image called `openpdc` from the local [`Dockerfile`](./Dockerfile) script:
+```sh
+docker build -t openpdc .
+```
+
+### Deploy and Run Docker Image to a Container
+This deploys and runs docker image `openpdc` to a container called `opendc-test` and exposes container ports to local machine:
+```sh
+docker run -d --name openpdc-test -p 8280:8280 -p 7165:7165 -p 6175:6175 -p 8900:8900 openpdc
+```
+
+### Tag Docker Image
+This tags the `openpdc` docker image as `gridprotectionalliance/openpdc:v2.9.148`, creating a copy of the image that can be pushed to [dockerhub](https://hub.docker.com/repository/docker/gridprotectionalliance/openpdc/general):
+```sh
+docker tag openpdc gridprotectionalliance/openpdc:v2.9.148
+```
+
+### Push Tagged Docker Image to dockerhub
+This push the tagged image `gridprotectionalliance/openpdc:v2.9.148` to dockerhub:
+```sh
+docker push gridprotectionalliance/openpdc:v2.9.148
+```
+
+### Open Shell Session Into Running Container
+This connects a shell session, like SSH, to to the running container called `openpdc-test`:
+```sh
+docker exec -it openpdc-test /bin/bash
+```
+
+### Run openPDC Console from Container Shell Session
+This runs the openPDC Console application from the container shell session, credentials will need to be provided (see below):
+```sh
+mono openPDCConsole.exe
+```
+
+### Open Web Interface
+The following URL will open the openPDC web management interface for a container listening on 8280, credentials will need to be provided (see below):
+
+http://localhost:8280/
+
+
+### Default Credentials
+* username: `.\admin`
+* password: `admin`
+

--- a/Source/Dockerfile
+++ b/Source/Dockerfile
@@ -50,7 +50,7 @@ RUN sqlite3 -line /opt/openPDC/ConfigurationCache/openPDC.db "INSERT INTO UserAc
     sqlite3 -line /opt/openPDC/ConfigurationCache/openPDC.db "INSERT INTO ApplicationRoleUserAccount(ApplicationRoleID, UserAccountID) VALUES((SELECT ID FROM ApplicationRole WHERE Name = 'Administrator'), (SELECT ID FROM UserAccount WHERE Name = '${OPENPDC_USER}'));"
 
 # Expose necessary ports
-EXPOSE 8280 7165 6175 8900
+EXPOSE 8280 7165 6165 8900
 
 # Start the openPDC service with the -RunAsConsole parameter
 CMD ["mono", "openPDC.exe", "-RunAsConsole"]

--- a/Source/Dockerfile
+++ b/Source/Dockerfile
@@ -1,0 +1,56 @@
+# Use the latest Mono image as the base
+FROM mono:latest
+
+# Set environment variables
+ENV OPENPDC_VERSION 2.9.148
+ENV OPENPDC_GROUP openpdc
+ENV OPENPDC_USER admin
+ENV OPENPDC_PASS admin
+
+# Install dependencies and tools
+RUN apt-get update && apt-get install -y \
+    wget \
+    unzip \
+    sqlite3 \
+    build-essential \
+    libpam0g-dev \
+    openssl \
+    passwd
+
+# Create a new user and group
+RUN groupadd -r $OPENPDC_GROUP && \
+    sh -c 'useradd -r -g $OPENPDC_GROUP -d /home/$OPENPDC_USER -m -s /bin/bash -p $(openssl passwd -1 $OPENPDC_PASS) $OPENPDC_USER'
+
+# Set password aging policies
+RUN chage -M 99999 $OPENPDC_USER && \
+    chage -m 0 $OPENPDC_USER && \
+    chage -W 7 $OPENPDC_USER
+
+# Download and unzip openPDC POSIX release
+RUN wget https://github.com/GridProtectionAlliance/openPDC/releases/download/v${OPENPDC_VERSION}/openPDC-POSIX.zip && \
+    unzip openPDC-POSIX.zip -d /opt && \
+    rm openPDC-POSIX.zip
+
+# Set the working directory
+WORKDIR /opt/openPDC
+
+# Generate a service certificate
+RUN mono MonoGenCert.exe openPDC
+
+# Enable local user auth for openPDC
+RUN echo "Enabling security for openPDC..." && \
+    cd UnixTools/ && \
+    gcc -c -Wall -Werror -fpic GSF.POSIX.c && \
+    gcc -shared -o GSF.POSIX.so GSF.POSIX.o -lpam -lpam_misc -lcrypt && \
+    cp -v GSF.POSIX.so .. && \
+    sed -i.backup -e '/name="SecureRemoteInteractions"/ s/value="False"/value="True"/' ../openPDC.exe.config
+
+# Add user directly to the configuration database
+RUN sqlite3 -line /opt/openPDC/ConfigurationCache/openPDC.db "INSERT INTO UserAccount(Name, DefaultNodeID) VALUES('${OPENPDC_USER}', (SELECT ID FROM Node));" && \
+    sqlite3 -line /opt/openPDC/ConfigurationCache/openPDC.db "INSERT INTO ApplicationRoleUserAccount(ApplicationRoleID, UserAccountID) VALUES((SELECT ID FROM ApplicationRole WHERE Name = 'Administrator'), (SELECT ID FROM UserAccount WHERE Name = '${OPENPDC_USER}'));"
+
+# Expose necessary ports
+EXPOSE 8280 7165 6175 8900
+
+# Start the openPDC service with the -RunAsConsole parameter
+CMD ["mono", "openPDC.exe", "-RunAsConsole"]


### PR DESCRIPTION
This adds `Dockerfile` for openPDC and a readme, contents pasted below:

### Build Docker Image
This builds an image called `openpdc` from the local [`Dockerfile`](./Dockerfile) script:
```sh
docker build -t openpdc .
```

### Deploy and Run Docker Image to a Container
This deploys and runs docker image `openpdc` to a container called `opendc-test` and exposes container ports to local machine:
```sh
docker run -d --name openpdc-test -p 8280:8280 -p 7165:7165 -p 6175:6175 -p 8900:8900 openpdc
```

### Tag Docker Image
This tags the `openpdc` docker image as `gridprotectionalliance/openpdc:v2.9.148`, creating a copy of the image that can be pushed to [dockerhub](https://hub.docker.com/repository/docker/gridprotectionalliance/openpdc/general):
```sh
docker tag openpdc gridprotectionalliance/openpdc:v2.9.148
```

### Push Tagged Docker Image to dockerhub
This pushes the tagged image `gridprotectionalliance/openpdc:v2.9.148` to dockerhub:
```sh
docker push gridprotectionalliance/openpdc:v2.9.148
```

### Open Shell Session Into Running Container
This connects a shell session, like SSH, to to the running container called `openpdc-test`:
```sh
docker exec -it openpdc-test /bin/bash
```

### Run openPDC Console from Container Shell Session
This runs the openPDC Console application from the container shell session, credentials will need to be provided (see below):
```sh
mono openPDCConsole.exe
```

### Open Web Interface
The following URL will open the openPDC web management interface for a container listening on 8280, credentials will need to be provided (see below):

http://localhost:8280/


### Default Credentials
* username: `.\admin`
* password: `admin`

