### PR TITLE
PDC-14 Clean up using statements in device status pages

### DIFF
--- a/Source/Applications/openPDC/openPDC/wwwroot/DeviceStatus.cshtml
+++ b/Source/Applications/openPDC/openPDC/wwwroot/DeviceStatus.cshtml
@@ -20,16 +20,17 @@
 //       Generated original version of source code.
 //
 //*****************************************************************************************************@
-@using GSF
-@using GSF.Data.Model
-@using GSF.Web.Model
-@using GSF.Web
-@using GSF.Web.Shared
-@using GSF.Web.Shared.Model
 @using System.Data
 @using System.Linq
 @using System.Net.Http
+@using GSF
+@using GSF.Data.Model
+@using GSF.Web
+@using GSF.Web.Model
+@using GSF.Web.Shared
+@using GSF.Web.Shared.Model
 @using GrafanaAdapters
+@using GrafanaAdapters.Model.Database
 @using openPDC.Model
 @using Random = GSF.Security.Cryptography.Random
 @inherits ExtendedTemplateBase<AppModel>

--- a/Source/Applications/openPDC/openPDC/wwwroot/ParentStatus.cshtml
+++ b/Source/Applications/openPDC/openPDC/wwwroot/ParentStatus.cshtml
@@ -20,16 +20,17 @@
 //       Generated original version of source code.
 //
 //*****************************************************************************************************@
-@using GSF
-@using GSF.Data.Model
-@using GSF.Web.Model
-@using GSF.Web
-@using GSF.Web.Shared
-@using GSF.Web.Shared.Model
 @using System.Data
 @using System.Linq
 @using System.Net.Http
+@using GSF
+@using GSF.Data.Model
+@using GSF.Web
+@using GSF.Web.Model
+@using GSF.Web.Shared
+@using GSF.Web.Shared.Model
 @using GrafanaAdapters
+@using GrafanaAdapters.Model.Database
 @using openPDC.Model
 @using Random = GSF.Security.Cryptography.Random
 @inherits ExtendedTemplateBase<AppModel>


### PR DESCRIPTION
Mainly fixes this issue, as some classes moved to the `GrafanaAdapters.Model.Database` namespace.

![image](https://github.com/user-attachments/assets/9ea75247-d549-4767-99bc-874398344d38)